### PR TITLE
metadata: remove app.yaml version

### DIFF
--- a/.registry/app.yaml
+++ b/.registry/app.yaml
@@ -6,7 +6,6 @@ overview: |
   An environment with built-in network and classes that let you provision
   resources with minimal node requirements in Azure.
 overviewShort: "Minimal environment for Azure."
-version: v0.2.0
 maintainers:
   - name: "Muvaffak Onus"
     email: "monus@upbound.io"


### PR DESCRIPTION
## Overview

We have observed that we appear to be treating stack version as having
two sources of truth: the app.yaml, and the docker tag. We plan to move
away from using the version in `app.yaml` as part of making it simpler
to manage the versions for our stacks.

## Testing done

I have tested this locally, and we will need https://github.com/crossplane/crossplane/issues/1307 to be done before we can merge this.